### PR TITLE
ShouldDuplicateByDefault Option

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -76,9 +76,7 @@ const defaultSharingMode = Deno.env.get("DEFAULT_SHARING_MODE") ?? "private";
 
 const duplicateByDefault: boolean = (defaultSharingMode === "public")
 
-if (sid === undefined || exportingProjectName === undefined || importingProjectName === undefined) {
-  console.log("Environmental variables are missing.");
-} else {
+if (sid !== undefined && exportingProjectName !== undefined && importingProjectName !== undefined) {
   console.log(`Exporting a json file from "/${exportingProjectName}"...`);
   const pages = await exportJSON(exportingProjectName, sid);
   console.log("exported: ", pages);
@@ -98,4 +96,6 @@ if (sid === undefined || exportingProjectName === undefined || importingProjectN
   } else {
     console.log("No page to be imported found.");
   }
+} else {
+  console.log("Environmental variables are missing.");
 }

--- a/index.ts
+++ b/index.ts
@@ -72,9 +72,7 @@ async function importJSON(
 const sid = Deno.env.get("SID");
 const exportingProjectName = Deno.env.get("SOURCE_PROJECT_NAME"); //インポート元(本来はprivateプロジェクト)
 const importingProjectName = Deno.env.get("DESTINATION_PROJECT_NAME"); //インポート先(publicプロジェクト)
-const defaultSharingMode = Deno.env.get("DEFAULT_SHARING_MODE") ?? "private";
-
-const duplicateByDefault: boolean = (defaultSharingMode === "public")
+const shouldDuplicateByDefault: boolean = (Deno.env.get("SHOULD_DUPLICATE_BY_DEFAULT") === "True");
 
 if (sid !== undefined && exportingProjectName !== undefined && importingProjectName !== undefined) {
   console.log(`Exporting a json file from "/${exportingProjectName}"...`);
@@ -87,7 +85,7 @@ if (sid !== undefined && exportingProjectName !== undefined && importingProjectN
     } else if (lines.some((line) => line.includes("[public.icon]"))) {
       return true;
     } else {
-      return duplicateByDefault;
+      return shouldDuplicateByDefault;
     }
   });
   if (importingPages.length > 0) {

--- a/index.ts
+++ b/index.ts
@@ -69,24 +69,33 @@ async function importJSON(
   );
 }
 
-
 const sid = Deno.env.get("SID");
 const exportingProjectName = Deno.env.get("SOURCE_PROJECT_NAME"); //インポート元(本来はprivateプロジェクト)
 const importingProjectName = Deno.env.get("DESTINATION_PROJECT_NAME"); //インポート先(publicプロジェクト)
+const defaultSharingMode = Deno.env.get("DEFAULT_SHARING_MODE") ?? "private";
 
-if (sid !== undefined && exportingProjectName !== undefined && importingProjectName !== undefined) {
+const duplicateByDefault: boolean = (defaultSharingMode === "public")
+
+if (sid === undefined || exportingProjectName === undefined || importingProjectName === undefined) {
+  console.log("Environmental variables are missing.");
+} else {
   console.log(`Exporting a json file from "/${exportingProjectName}"...`);
   const pages = await exportJSON(exportingProjectName, sid);
   console.log("exported: ", pages);
-  const importPages = pages.filter(({ lines }) =>
-      lines.some((line) => line.includes("[public.icon]"))
-  );
-  if (importPages.length > 0) {
-    console.log(`Importing the page data to "/${importingProjectName}"...`);
-    await importJSON(importingProjectName, sid, importPages);
+
+  const importingPages = pages.filter(({ lines }) => {
+    if (lines.some((line) => line.includes("[private.icon]"))) {
+      return false;
+    } else if (lines.some((line) => line.includes("[public.icon]"))) {
+      return true;
+    } else {
+      return duplicateByDefault;
+    }
+  });
+  if (importingPages.length > 0) {
+    console.log(`Importing ${importingPages.length} pages to "/${importingProjectName}"...`);
+    await importJSON(importingProjectName, sid, importingPages);
   } else {
     console.log("No page to be imported found.");
   }
-} else {
-  console.log("Environmental variables lacking")
 }


### PR DESCRIPTION
目的
- `[private.icon]`をつけたページ以外全てをDuplicateするようなオプションが欲しい。

やったこと
- `SHOULD_DUPLICATE_BY_DEFAULT`という新しい環境変数を読み込むようにした。
  - `[public.icon]`も`[private.icon]`もついていないページが転送されるかどうかが、この変数によって決まる。
    - `SHOULD_DUPLICATE_BY_DEFAULT="True"`の場合は転送され、それ以外の場合は転送されない。
  - 変数が設定されていない場合も転送されないため、従来の実装と同じ挙動になる。
  - APIの制限にぶつかったため、テストはまだ出来ていない。